### PR TITLE
:sparkles:基礎代謝、エネルギー消費量の小数点第一位以下を非表示

### DIFF
--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -1,5 +1,5 @@
-<p>基礎代謝: <%= session[:bmr] %> kcal/day</p>
-<p>1日の推定エネルギー消費量 (TDEE): <%= session[:tdee] %> kcal/day</p>
+<p>基礎代謝: <%= session[:bmr].floor %> kcal/day</p>
+<p>1日の推定エネルギー消費量 (TDEE): <%= session[:tdee].floor %> kcal/day</p>
 <p>目標体重<%= session[:target_weight] %> kg </p>
 <p>現在の体重<%= session[:weight] %> kg </p>
 <p>必要なタンパク質<%= session[:protein].floor %> g</p>


### PR DESCRIPTION
## 概要

基礎代謝、エネルギー消費量の小数点第一位以下を非表示にするようにロジックを追加

## 変更点

基礎代謝、エネルギー消費量の小数点第一位以下を非表示にするようにfloorロジックを追加
## 影響範囲

ダッシュボード
